### PR TITLE
Removes trailing colons in docstring section titles. Fixes #44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This document highlights high-level changes made to this program.
 + Use enums for `data_type`. (#61)
 + Use an ordered dict internally for `DiscreteLegend`.
 + Add a `discrete_legend_colors` arg to the WaferMapPanel constructor.
++ Minor updates to docstring formatting (#44)
 
 
 ## 1.0.25 / 2018-10-10

--- a/wafer_map/gen_fake_data.py
+++ b/wafer_map/gen_fake_data.py
@@ -58,8 +58,8 @@ def generate_fake_data(**kwargs):
         Datatype. Valid options are "discrete" and "continuous".
         Defaults to "continuous".
 
-    Examples of Offsets:
-    --------------------
+    Examples of Offsets
+    -------------------
     The ``X`` denotes the center of the wafer::
 
       x_offset = 0          x_offset = 0
@@ -78,8 +78,8 @@ def generate_fake_data(**kwargs):
       |           |         |           |
       |-----------|         X-----------|
 
-    Notes:
-    ------
+    Notes
+    -----
     Another rewrite, this time starting from the top. We will not look at
     the wafer map until I'm satisfied with the numerical values.
 


### PR DESCRIPTION
Fixes #44.