### PR TITLE
Fix sign error in wm_core.draw_die_gridlines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This document highlights high-level changes made to this program.
 
 
 ## Unreleased
++ Fix x-position of gridlines (#38)
 
 
 ## 1.1.1 / 2018-10-12

--- a/wafer_map/wm_core.py
+++ b/wafer_map/wm_core.py
@@ -747,7 +747,7 @@ def draw_die_gridlines(wf):
     edge = (wf.dia / 2) * 1.05
 
     # calculate the values for the gridlines
-    x_ref = math.modf(wf.center_xy[0])[0] * x_size + (x_size/2)
+    x_ref = -math.modf(wf.center_xy[0])[0] * x_size + (x_size / 2)
     pos_vert = np.arange(x_ref, edge, x_size)
     neg_vert = np.arange(x_ref, -edge, -x_size)
 


### PR DESCRIPTION
Fix #38

Before: 
![image](https://user-images.githubusercontent.com/17056237/61007565-f9b2be80-a321-11e9-8703-24fc07b031b8.png)

After
![image](https://user-images.githubusercontent.com/17056237/61007600-13540600-a322-11e9-9498-2fdc298d285a.png)